### PR TITLE
[Update] Add ability to GET user-specific annotations

### DIFF
--- a/extension/annotator-original.js
+++ b/extension/annotator-original.js
@@ -13025,7 +13025,7 @@ HttpStorage.prototype._apiRequestOptions = function (action, obj) {
         opts = $.extend(opts, {data: obj});
         // sneak in the facebook_id to end of uri as search query
         var facebook_id = window.localStorage.getItem('facebook_id');
-        opts.data.uri += '?user=' + facebook_id;
+        // opts.data.uri += '?user=' + facebook_id;
         return opts;
     }
 

--- a/extension/annotator-original.js
+++ b/extension/annotator-original.js
@@ -12517,7 +12517,9 @@ SimpleIdentityPolicy = function SimpleIdentityPolicy() {
      *
      *     app.ident.identity = 'bob';
      */
-    this.identity = null;
+    debugger;
+    var _THISIDENTITY = this.identity;
+    // this.identity = null;
 };
 exports.SimpleIdentityPolicy = SimpleIdentityPolicy;
 
@@ -12528,6 +12530,9 @@ exports.SimpleIdentityPolicy = SimpleIdentityPolicy;
  * Returns the current user identity.
  */
 SimpleIdentityPolicy.prototype.who = function () {
+    debugger;
+    var THIS = this;
+    var THISIDENTITY = this.identity;
     return this.identity;
 };
 
@@ -12977,7 +12982,7 @@ HttpStorage.prototype.setHeader = function (key, value) {
  * :rtype: jqXHR
  */
 HttpStorage.prototype._apiRequest = function (action, obj) {
-    debugger; // added 2015-10-26 16:57
+    // debugger; // added 2015-10-26 16:57
     var id = obj && obj.id;
     var url = this._urlFor(action, id);
     var options = this._apiRequestOptions(action, obj);
@@ -13025,6 +13030,15 @@ HttpStorage.prototype._apiRequestOptions = function (action, obj) {
     // Don't JSONify obj if making search request.
     if (action === "search") {
         opts = $.extend(opts, {data: obj});
+        // sneak in the facebook_id to end of uri as search query
+        debugger; // added 2015-10-26 18:18 PDT
+        var identityVariable = annotator.identity;
+        console.log('identityVariable:', identityVariable);
+        var who = annotator.identity.SimpleIdentityPolicy.prototype.who();
+        console.log('who:', who);
+        var defaultIdentity = annotator.identity.SimpleIdentityPolicy.identity;
+        console.log('defaultIdentity:', defaultIdentity);
+        // opts.uri = opts.uri + '?user=' + app.ident.identity; // comment added 2015-10-26 18:25 PDT
         return opts;
     }
 
@@ -15134,6 +15148,7 @@ function main(options) {
     };
 
     function start(app) {
+        debugger; // added 2015-10-26 20:36 PDT
         var ident = app.registry.getUtility('identityPolicy');
         var authz = app.registry.getUtility('authorizationPolicy');
 

--- a/extension/annotator-original.js
+++ b/extension/annotator-original.js
@@ -12977,9 +12977,15 @@ HttpStorage.prototype.setHeader = function (key, value) {
  * :rtype: jqXHR
  */
 HttpStorage.prototype._apiRequest = function (action, obj) {
+    debugger; // added 2015-10-26 16:57
     var id = obj && obj.id;
     var url = this._urlFor(action, id);
     var options = this._apiRequestOptions(action, obj);
+
+    var aiSIPi = annotator.identity.SimpleIdentityPolicy.identity;
+    console.log("annotator.identity.SimpleIdentityPolicy.identity:", aiSIPi);
+    var aiSIPpw = annotator.identity.SimpleIdentityPolicy.prototype.who();
+    console.log("annotator.identity.SimpleIdentityPolicy.prototype.who():", aiSIPpw);
 
     var request = $.ajax(url, options);
 

--- a/extension/annotator-original.js
+++ b/extension/annotator-original.js
@@ -12327,7 +12327,7 @@ App.prototype.destroy = function () {
  * :rtype: Promise
  */
 App.prototype.runHook = function (name, args) {
-  debugger;
+  // debugger;
     var results = [];
     for (var i = 0, len = this.modules.length; i < len; i++) {
         var mod = this.modules[i];
@@ -12982,10 +12982,7 @@ HttpStorage.prototype._apiRequest = function (action, obj) {
     var url = this._urlFor(action, id);
     var options = this._apiRequestOptions(action, obj);
 
-    var aiSIPi = annotator.identity.SimpleIdentityPolicy.identity;
-    console.log("annotator.identity.SimpleIdentityPolicy.identity:", aiSIPi);
-    var aiSIPpw = annotator.identity.SimpleIdentityPolicy.prototype.who();
-    console.log("annotator.identity.SimpleIdentityPolicy.prototype.who():", aiSIPpw);
+
 
     var request = $.ajax(url, options);
 
@@ -13374,7 +13371,7 @@ StorageAdapter.prototype._cycle = function (
 
     return this.runHook(beforeEvent, [obj])
         .then(function () {
-          debugger;
+          // debugger;
             var safeCopy = $.extend(true, {}, obj);
             delete safeCopy._local;
 
@@ -13384,7 +13381,7 @@ StorageAdapter.prototype._cycle = function (
             return Promise.resolve(result);
         })
         .then(function (ret) {
-          debugger;
+          // debugger;
             // Empty obj without changing identity
             for (var k in obj) {
                 if (obj.hasOwnProperty(k)) {
@@ -14803,7 +14800,7 @@ Highlighter.prototype.drawAll = function (annotations) {
 //
 // Returns an Array of drawn highlight elements.
 Highlighter.prototype.draw = function (annotation) {
-  debugger;
+  // debugger;
     var normedRanges = [];
 
     for (var i = 0, ilen = annotation.ranges.length; i < ilen; i++) {
@@ -15714,7 +15711,7 @@ var Viewer = exports.Viewer = Widget.extend({
                 self._onEditClick(e);
             })
             .on("click." + NS, '.annotator-delete', function (e) {
-              debugger;
+              // debugger;
                 self._onDeleteClick(e);
             })
             .on("mouseenter." + NS, function () {

--- a/extension/annotator-original.js
+++ b/extension/annotator-original.js
@@ -12517,9 +12517,7 @@ SimpleIdentityPolicy = function SimpleIdentityPolicy() {
      *
      *     app.ident.identity = 'bob';
      */
-    debugger;
-    var _THISIDENTITY = this.identity;
-    // this.identity = null;
+    this.identity = null;
 };
 exports.SimpleIdentityPolicy = SimpleIdentityPolicy;
 
@@ -12530,9 +12528,6 @@ exports.SimpleIdentityPolicy = SimpleIdentityPolicy;
  * Returns the current user identity.
  */
 SimpleIdentityPolicy.prototype.who = function () {
-    debugger;
-    var THIS = this;
-    var THISIDENTITY = this.identity;
     return this.identity;
 };
 
@@ -12987,8 +12982,6 @@ HttpStorage.prototype._apiRequest = function (action, obj) {
     var url = this._urlFor(action, id);
     var options = this._apiRequestOptions(action, obj);
 
-
-
     var request = $.ajax(url, options);
 
     // Append the id and action to the request object
@@ -13032,14 +13025,15 @@ HttpStorage.prototype._apiRequestOptions = function (action, obj) {
         opts = $.extend(opts, {data: obj});
         // sneak in the facebook_id to end of uri as search query
         debugger; // added 2015-10-26 18:18 PDT
-        var identityVariable = annotator.identity;
-        console.log('identityVariable:', identityVariable);
-        var who = annotator.identity.SimpleIdentityPolicy.prototype.who();
-        console.log('who:', who);
-        var defaultIdentity = annotator.identity.SimpleIdentityPolicy.identity;
-        console.log('defaultIdentity:', defaultIdentity);
-        // opts.uri = opts.uri + '?user=' + app.ident.identity; // comment added 2015-10-26 18:25 PDT
-        return opts;
+        chrome.storage.sync.get('facebook_id', function(obj) {
+          debugger;
+          if (!obj['facebook_id']) {
+            console.error('Failed to retrieve facebook_id from chrome.storage');
+            return;
+          }
+          opts.uri = opts.uri + '?user=' + obj.facebook_id;
+          return opts;
+        });
     }
 
     var data = obj && JSON.stringify(obj);
@@ -15148,7 +15142,6 @@ function main(options) {
     };
 
     function start(app) {
-        debugger; // added 2015-10-26 20:36 PDT
         var ident = app.registry.getUtility('identityPolicy');
         var authz = app.registry.getUtility('authorizationPolicy');
 

--- a/extension/annotator-original.js
+++ b/extension/annotator-original.js
@@ -13024,16 +13024,9 @@ HttpStorage.prototype._apiRequestOptions = function (action, obj) {
     if (action === "search") {
         opts = $.extend(opts, {data: obj});
         // sneak in the facebook_id to end of uri as search query
-        debugger; // added 2015-10-26 18:18 PDT
-        chrome.storage.sync.get('facebook_id', function(obj) {
-          debugger;
-          if (!obj['facebook_id']) {
-            console.error('Failed to retrieve facebook_id from chrome.storage');
-            return;
-          }
-          opts.uri = opts.uri + '?user=' + obj.facebook_id;
-          return opts;
-        });
+        var facebook_id = window.localStorage.getItem('facebook_id');
+        opts.data.uri += '?user=' + facebook_id;
+        return opts;
     }
 
     var data = obj && JSON.stringify(obj);

--- a/extension/dist/js/main.js
+++ b/extension/dist/js/main.js
@@ -20320,29 +20320,12 @@ var renderComponents = function() {
   React.render(React.createElement(App, null), document.getElementById('scrollview'));
 }
 
-var tokenListener = function(changes) {
-  if (changes.access_token && changes.access_token.newValue) {
-    renderComponents();
-    test.annotate();
-  }
-  chrome.storage.onChanged.removeListener(tokenListener);
-};
-
-chrome.storage.sync.get('access_token', function(obj) {
-  if (obj['access_token']) {
-    renderComponents();
-    test.annotate();
-  } else {
-    chrome.storage.onChanged.addListener(tokenListener);
-  }
-});
-
 var identityListener = function(changes) {
   if (changes.facebook_id && changes.facebook_id.newValue) {
     renderComponents();
     test.annotate();
+    chrome.storage.onChanged.removeListener(identityListener);
   }
-  chrome.storage.onChanged.removeListener(identityListener);
 };
 
 chrome.storage.sync.get('facebook_id', function(obj) {

--- a/extension/dist/js/main.js
+++ b/extension/dist/js/main.js
@@ -20311,7 +20311,7 @@ var renderComponents = function() {
 }
 
 var tokenListener = function(changes) {
-  console.log("inside addlistener", changes);
+  console.log("inside tokenlistener (main.js line 14)", changes);
   if (changes.access_token.newValue) {
     renderComponents();
     test.annotate();
@@ -20320,11 +20320,37 @@ var tokenListener = function(changes) {
 }
 
 chrome.storage.sync.get('access_token', function(obj) {
+  console.log('main.js > chrome storage get token (line 23)');
   if (obj['access_token']) {
+    console.log('main.js > chrome storage get token > if ( access token ) (line 25)');
     renderComponents();
+    console.log('main.js > chrome.storage.sync.get > if ( access token ) (line 27)');
     test.annotate();
   } else {
+    console.log('main.js > chrome.storage.sync.get > else (line 30)');
     chrome.storage.onChanged.addListener(tokenListener);
+  }
+})
+
+var identityListener = function(changes) {
+  console.log("inside identitylistener (main.js line 36)", changes);
+  if (changes.facebook_id.newValue) {
+    renderComponents();
+    test.annotate();
+  }
+  chrome.storage.onChanged.removeListener(identityListener);
+}
+
+chrome.storage.sync.get('facebook_id', function(obj) {
+  console.log('main.js > chrome.storage get fb id (line 45)');
+  if (obj['access_token']) {
+    console.log('main.js > chrome storage get fb id > if ( access token ) (line 47)');
+    renderComponents();
+    console.log('main.js > chrome storage get fb id > if ( access token ) (line 49)');
+    test.annotate();
+  } else {
+    console.log('main.js > chrome storage get fb id > else (line 52)');
+    chrome.storage.onChanged.addListener(identityListener);
   }
 })
 

--- a/extension/dist/js/main.js
+++ b/extension/dist/js/main.js
@@ -20388,7 +20388,6 @@ exports.annotate = function(event) {
 
   var app = new annotator.App();
   app.include(annotator.ui.main)
-     .include(annotator.identity.simple)
      .include(annotator.storage.http, {
         prefix: 'https://onwords-test-server.herokuapp.com',
         urls: {
@@ -20402,30 +20401,16 @@ exports.annotate = function(event) {
      .include(renderAnnotations);
 
   chrome.storage.sync.get('facebook_id', function(obj) {
-    console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 32), obj:', obj);
     if (!obj['facebook_id']) {
-      console.error('Unable to access facebook_id from chrome.storage (test.js line 34)');
+      console.error('Unable to access facebook_id from chrome.storage');
       return;
     }
-    console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 37), obj.facebook_id:', obj.facebook_id);
-
     app.start()
        .then(function() {
-        debugger;
-         app.ident.identity = obj.facebook_id;
-         console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 39), app.ident.identity:', app.ident.identity);
-         console.log('line app.ident.identity = obj.facebook_id; success?');
-         console.log('test.js > app.start().then() cb > chro.stor.sync.get(fbID) (line 42), app.ident:', app.ident);
-         var a = app;
-         var ai = app.ident;
-         var aii = app.ident.identity;
+         window.localStorage.setItem('facebook_id', obj.facebook_id);
          app.annotations.load({uri: window.location.href.split("?")[0]});
-       })
+       });
   });
-
-
-
-
 }
 
 },{"./annotationRender":157}]},{},[170]);

--- a/extension/dist/js/main.js
+++ b/extension/dist/js/main.js
@@ -20259,12 +20259,6 @@ module.exports = MinimizeButton;
 var React = require('react');
 
 var AnnotatorHead = React.createClass({displayName: "AnnotatorHead",
-  purgeHandler: function() {
-    console.log('about to purge chrome.storage');
-    chrome.storage.sync.clear()
-    console.log('chrome.storage purged');
-  }, 
-
   render: function() {
     return (
       React.createElement("div", {className: "annotator-head-container"}, 
@@ -20272,9 +20266,7 @@ var AnnotatorHead = React.createClass({displayName: "AnnotatorHead",
           React.createElement("img", {src: "http://frsports-bucket-0001.s3.amazonaws.com/wp-content/uploads/sites/6/2015/02/26224056/white-llama.jpg", className: "annotator-user-image"})
         ), 
 
-        React.createElement("div", {className: "username-container"}, "Hoonthegoon9000", React.createElement("br", null), 
-          React.createElement("span", {onClick: this.purgeHandler}, "Purge ", React.createElement("code", null, "chrome.storage"))
-        ), 
+        React.createElement("div", {className: "username-container"}, "Hoonthegoon9000"), 
 
         React.createElement("div", {className: "profile-statistics-container"}, 
           React.createElement("div", {className: "posts-container"}, 

--- a/extension/dist/js/main.js
+++ b/extension/dist/js/main.js
@@ -20401,21 +20401,28 @@ exports.annotate = function(event) {
      .include(pageUri)
      .include(renderAnnotations);
 
-  app.start()
-     .then(function() {
-        chrome.storage.sync.get('facebook_id', function(obj) {
-          console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 32), obj:', obj);
-          if (!obj['facebook_id']) {
-            console.error('Unable to access facebook_id from chrome.storage (test.js line 34)');
-            return;
-          }
-          console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 37), obj.facebook_id:', obj.facebook_id);
-          app.ident.identity = obj.facebook_id;
-          console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 39), app.ident.identity:', app.ident.identity);
-          console.log('line app.ident.identity = obj.facebook_id; success?');
-          app.annotations.load({uri: window.location.href.split("?")[0]});
-        });
-     })
+  chrome.storage.sync.get('facebook_id', function(obj) {
+    console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 32), obj:', obj);
+    if (!obj['facebook_id']) {
+      console.error('Unable to access facebook_id from chrome.storage (test.js line 34)');
+      return;
+    }
+    console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 37), obj.facebook_id:', obj.facebook_id);
+
+    app.start()
+       .then(function() {
+        debugger;
+         app.ident.identity = obj.facebook_id;
+         console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 39), app.ident.identity:', app.ident.identity);
+         console.log('line app.ident.identity = obj.facebook_id; success?');
+         console.log('test.js > app.start().then() cb > chro.stor.sync.get(fbID) (line 42), app.ident:', app.ident);
+         var a = app;
+         var ai = app.ident;
+         var aii = app.ident.identity;
+         app.annotations.load({uri: window.location.href.split("?")[0]});
+       })
+  });
+
 
 
 

--- a/extension/dist/js/main.js
+++ b/extension/dist/js/main.js
@@ -20334,7 +20334,7 @@ var tokenListener = function(changes) {
     test.annotate();
   }
   chrome.storage.onChanged.removeListener(tokenListener);
-}
+};
 
 chrome.storage.sync.get('access_token', function(obj) {
   if (obj['access_token']) {
@@ -20343,7 +20343,7 @@ chrome.storage.sync.get('access_token', function(obj) {
   } else {
     chrome.storage.onChanged.addListener(tokenListener);
   }
-})
+});
 
 var identityListener = function(changes) {
   if (changes.facebook_id && changes.facebook_id.newValue) {
@@ -20351,16 +20351,16 @@ var identityListener = function(changes) {
     test.annotate();
   }
   chrome.storage.onChanged.removeListener(identityListener);
-}
+};
 
 chrome.storage.sync.get('facebook_id', function(obj) {
-  if (obj['access_token']) {
+  if (obj['facebook_id']) {
     renderComponents();
     test.annotate();
   } else {
     chrome.storage.onChanged.addListener(identityListener);
   }
-})
+});
 
 },{"./components/app":165,"./test":171,"react":156}],171:[function(require,module,exports){
 var renderAnnotations = require('./annotationRender');
@@ -20398,6 +20398,7 @@ exports.annotate = function(event) {
     app.start()
        .then(function() {
          window.localStorage.setItem('facebook_id', obj.facebook_id);
+         console.log('facebook_id set in localStorage');
          app.annotations.load({uri: window.location.href.split("?")[0]});
        });
   });

--- a/extension/dist/js/main.js
+++ b/extension/dist/js/main.js
@@ -20003,7 +20003,7 @@ var AnnotatorBody = React.createClass({displayName: "AnnotatorBody",
     })
     chrome.storage.onChanged.addListener(function(changes) {
       console.log('annotator body, storage updated', changes[uri]);
-      if (changes[uri].newValue) {
+      if (changes[uri] && changes[uri].newValue) {
         self.setState({annotations: changes[uri].newValue});
       }
     })
@@ -20329,7 +20329,7 @@ var renderComponents = function() {
 }
 
 var tokenListener = function(changes) {
-  if (changes.access_token.newValue) {
+  if (changes.access_token && changes.access_token.newValue) {
     renderComponents();
     test.annotate();
   }
@@ -20346,7 +20346,7 @@ chrome.storage.sync.get('access_token', function(obj) {
 })
 
 var identityListener = function(changes) {
-  if (changes.facebook_id.newValue) {
+  if (changes.facebook_id && changes.facebook_id.newValue) {
     renderComponents();
     test.annotate();
   }

--- a/extension/dist/js/main.js
+++ b/extension/dist/js/main.js
@@ -20257,6 +20257,12 @@ module.exports = MinimizeButton;
 var React = require('react');
 
 var AnnotatorHead = React.createClass({displayName: "AnnotatorHead",
+  purgeHandler: function() {
+    console.log('about to purge chrome.storage');
+    chrome.storage.sync.clear()
+    console.log('chrome.storage purged');
+  }, 
+
   render: function() {
     return (
       React.createElement("div", {className: "annotator-head-container"}, 
@@ -20265,7 +20271,8 @@ var AnnotatorHead = React.createClass({displayName: "AnnotatorHead",
         ), 
         
         React.createElement("span", null, "Jihoon Kim"), 
-        React.createElement("span", null, "Hoonthegoon9000")
+        React.createElement("span", null, "Hoonthegoon9000"), React.createElement("br", null), 
+        React.createElement("span", {onClick: this.purgeHandler}, "Purge ", React.createElement("code", null, "chrome.storage"))
       )
     );
   }

--- a/extension/dist/js/main.js
+++ b/extension/dist/js/main.js
@@ -20329,7 +20329,6 @@ var renderComponents = function() {
 }
 
 var tokenListener = function(changes) {
-  console.log("inside tokenlistener (main.js line 14)", changes);
   if (changes.access_token.newValue) {
     renderComponents();
     test.annotate();
@@ -20338,20 +20337,15 @@ var tokenListener = function(changes) {
 }
 
 chrome.storage.sync.get('access_token', function(obj) {
-  console.log('main.js > chrome storage get token (line 23)');
   if (obj['access_token']) {
-    console.log('main.js > chrome storage get token > if ( access token ) (line 25)');
     renderComponents();
-    console.log('main.js > chrome.storage.sync.get > if ( access token ) (line 27)');
     test.annotate();
   } else {
-    console.log('main.js > chrome.storage.sync.get > else (line 30)');
     chrome.storage.onChanged.addListener(tokenListener);
   }
 })
 
 var identityListener = function(changes) {
-  console.log("inside identitylistener (main.js line 36)", changes);
   if (changes.facebook_id.newValue) {
     renderComponents();
     test.annotate();
@@ -20360,14 +20354,10 @@ var identityListener = function(changes) {
 }
 
 chrome.storage.sync.get('facebook_id', function(obj) {
-  console.log('main.js > chrome.storage get fb id (line 45)');
   if (obj['access_token']) {
-    console.log('main.js > chrome storage get fb id > if ( access token ) (line 47)');
     renderComponents();
-    console.log('main.js > chrome storage get fb id > if ( access token ) (line 49)');
     test.annotate();
   } else {
-    console.log('main.js > chrome storage get fb id > else (line 52)');
     chrome.storage.onChanged.addListener(identityListener);
   }
 })

--- a/extension/js/auth.js
+++ b/extension/js/auth.js
@@ -13,7 +13,6 @@ function fetchToken() {
   }
 
   chrome.identity.launchWebAuthFlow(options, function(redirectUri) {
-
     if (chrome.runtime.lastError) {
       console.log(new Error(chrome.runtime.lastError));
       return;
@@ -59,7 +58,7 @@ function fetchFbProfile(accessToken) {
       profile.pic_url = resp.picture.data.url;
       profile.email = resp.email;
       chrome.storage.sync.set({'facebook_id': resp.id}, function() {
-        console.log('facebook_id set in storage');
+        console.log('facebook_id set in chrome.storage');
       });
       sendFbProfile(profile);
     }

--- a/extension/js/auth.js
+++ b/extension/js/auth.js
@@ -36,8 +36,11 @@ function fetchToken() {
 chrome.storage.sync.clear();
 
 chrome.browserAction.onClicked.addListener(function() {
+  console.log('browserAction clicked');
   chrome.storage.sync.get('access_token', function(obj) {
+    console.log('browserAction clicked, inside callback to get, obj:', obj);
     if (!obj['access_token']) {
+      console.log('browserAction clicked, inside callback to get, access_token not found');
       fetchToken();
     }
   });
@@ -55,6 +58,9 @@ function fetchFbProfile(accessToken) {
       profile.full_name = resp.name;
       profile.pic_url = resp.picture.data.url;
       profile.email = resp.email;
+      chrome.storage.sync.set({'facebook_id': resp.id}, function() {
+        console.log('facebook_id set in storage');
+      });
       sendFbProfile(profile);
     }
   }

--- a/extension/js/auth.js
+++ b/extension/js/auth.js
@@ -35,11 +35,8 @@ function fetchToken() {
 chrome.storage.sync.clear();
 
 chrome.browserAction.onClicked.addListener(function() {
-  console.log('browserAction clicked');
   chrome.storage.sync.get('access_token', function(obj) {
-    console.log('browserAction clicked, inside callback to get, obj:', obj);
     if (!obj['access_token']) {
-      console.log('browserAction clicked, inside callback to get, access_token not found, fetchToken to be called');
       fetchToken();
     }
   });
@@ -57,9 +54,7 @@ function fetchFbProfile(accessToken) {
       profile.full_name = resp.name;
       profile.pic_url = resp.picture.data.url;
       profile.email = resp.email;
-      chrome.storage.sync.set({'facebook_id': resp.id}, function() {
-        console.log('facebook_id set in chrome.storage');
-      });
+      chrome.storage.sync.set({'facebook_id': resp.id});
       sendFbProfile(profile);
     }
   }

--- a/extension/js/auth.js
+++ b/extension/js/auth.js
@@ -40,7 +40,7 @@ chrome.browserAction.onClicked.addListener(function() {
   chrome.storage.sync.get('access_token', function(obj) {
     console.log('browserAction clicked, inside callback to get, obj:', obj);
     if (!obj['access_token']) {
-      console.log('browserAction clicked, inside callback to get, access_token not found');
+      console.log('browserAction clicked, inside callback to get, access_token not found, fetchToken to be called');
       fetchToken();
     }
   });

--- a/src/js/components/annotator-view/annotator-body.js
+++ b/src/js/components/annotator-view/annotator-body.js
@@ -19,7 +19,7 @@ var AnnotatorBody = React.createClass({
     })
     chrome.storage.onChanged.addListener(function(changes) {
       console.log('annotator body, storage updated', changes[uri]);
-      if (changes[uri].newValue) {
+      if (changes[uri] && changes[uri].newValue) {
         self.setState({annotations: changes[uri].newValue});
       }
     })

--- a/src/js/components/header/header.js
+++ b/src/js/components/header/header.js
@@ -1,12 +1,6 @@
 var React = require('react');
 
 var AnnotatorHead = React.createClass({
-  purgeHandler: function() {
-    console.log('about to purge chrome.storage');
-    chrome.storage.sync.clear()
-    console.log('chrome.storage purged');
-  }, 
-
   render: function() {
     return (
       <div className='annotator-head-container'>
@@ -14,9 +8,7 @@ var AnnotatorHead = React.createClass({
           <img src='http://frsports-bucket-0001.s3.amazonaws.com/wp-content/uploads/sites/6/2015/02/26224056/white-llama.jpg' className='annotator-user-image' />
         </div>
 
-        <div className='username-container'>Hoonthegoon9000<br />
-          <span onClick={this.purgeHandler}>Purge <code>chrome.storage</code></span>
-        </div>
+        <div className='username-container'>Hoonthegoon9000</div>
 
         <div className='profile-statistics-container'>
           <div className='posts-container'>

--- a/src/js/components/header/header.js
+++ b/src/js/components/header/header.js
@@ -1,6 +1,12 @@
 var React = require('react');
 
 var AnnotatorHead = React.createClass({
+  purgeHandler: function() {
+    console.log('about to purge chrome.storage');
+    chrome.storage.sync.clear()
+    console.log('chrome.storage purged');
+  }, 
+
   render: function() {
     return (
       <div className='annotator-head-container'>
@@ -9,7 +15,8 @@ var AnnotatorHead = React.createClass({
         </div>
         
         <span>Jihoon Kim</span>
-        <span>Hoonthegoon9000</span>
+        <span>Hoonthegoon9000</span><br />
+        <span onClick={this.purgeHandler}>Purge <code>chrome.storage</code></span>
       </div>
     );
   }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -16,7 +16,7 @@ var tokenListener = function(changes) {
     test.annotate();
   }
   chrome.storage.onChanged.removeListener(tokenListener);
-}
+};
 
 chrome.storage.sync.get('access_token', function(obj) {
   if (obj['access_token']) {
@@ -25,7 +25,7 @@ chrome.storage.sync.get('access_token', function(obj) {
   } else {
     chrome.storage.onChanged.addListener(tokenListener);
   }
-})
+});
 
 var identityListener = function(changes) {
   if (changes.facebook_id && changes.facebook_id.newValue) {
@@ -33,13 +33,13 @@ var identityListener = function(changes) {
     test.annotate();
   }
   chrome.storage.onChanged.removeListener(identityListener);
-}
+};
 
 chrome.storage.sync.get('facebook_id', function(obj) {
-  if (obj['access_token']) {
+  if (obj['facebook_id']) {
     renderComponents();
     test.annotate();
   } else {
     chrome.storage.onChanged.addListener(identityListener);
   }
-})
+});

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -10,29 +10,12 @@ var renderComponents = function() {
   React.render(<App />, document.getElementById('scrollview'));
 }
 
-var tokenListener = function(changes) {
-  if (changes.access_token && changes.access_token.newValue) {
-    renderComponents();
-    test.annotate();
-  }
-  chrome.storage.onChanged.removeListener(tokenListener);
-};
-
-chrome.storage.sync.get('access_token', function(obj) {
-  if (obj['access_token']) {
-    renderComponents();
-    test.annotate();
-  } else {
-    chrome.storage.onChanged.addListener(tokenListener);
-  }
-});
-
 var identityListener = function(changes) {
   if (changes.facebook_id && changes.facebook_id.newValue) {
     renderComponents();
     test.annotate();
+    chrome.storage.onChanged.removeListener(identityListener);
   }
-  chrome.storage.onChanged.removeListener(identityListener);
 };
 
 chrome.storage.sync.get('facebook_id', function(obj) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -11,7 +11,7 @@ var renderComponents = function() {
 }
 
 var tokenListener = function(changes) {
-  console.log("inside addlistener", changes);
+  console.log("inside tokenlistener (main.js line 14)", changes);
   if (changes.access_token.newValue) {
     renderComponents();
     test.annotate();
@@ -20,10 +20,36 @@ var tokenListener = function(changes) {
 }
 
 chrome.storage.sync.get('access_token', function(obj) {
+  console.log('main.js > chrome storage get token (line 23)');
   if (obj['access_token']) {
+    console.log('main.js > chrome storage get token > if ( access token ) (line 25)');
     renderComponents();
+    console.log('main.js > chrome.storage.sync.get > if ( access token ) (line 27)');
     test.annotate();
   } else {
+    console.log('main.js > chrome.storage.sync.get > else (line 30)');
     chrome.storage.onChanged.addListener(tokenListener);
+  }
+})
+
+var identityListener = function(changes) {
+  console.log("inside identitylistener (main.js line 36)", changes);
+  if (changes.facebook_id.newValue) {
+    renderComponents();
+    test.annotate();
+  }
+  chrome.storage.onChanged.removeListener(identityListener);
+}
+
+chrome.storage.sync.get('facebook_id', function(obj) {
+  console.log('main.js > chrome.storage get fb id (line 45)');
+  if (obj['access_token']) {
+    console.log('main.js > chrome storage get fb id > if ( access token ) (line 47)');
+    renderComponents();
+    console.log('main.js > chrome storage get fb id > if ( access token ) (line 49)');
+    test.annotate();
+  } else {
+    console.log('main.js > chrome storage get fb id > else (line 52)');
+    chrome.storage.onChanged.addListener(identityListener);
   }
 })

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -11,7 +11,7 @@ var renderComponents = function() {
 }
 
 var tokenListener = function(changes) {
-  if (changes.access_token.newValue) {
+  if (changes.access_token && changes.access_token.newValue) {
     renderComponents();
     test.annotate();
   }
@@ -28,7 +28,7 @@ chrome.storage.sync.get('access_token', function(obj) {
 })
 
 var identityListener = function(changes) {
-  if (changes.facebook_id.newValue) {
+  if (changes.facebook_id && changes.facebook_id.newValue) {
     renderComponents();
     test.annotate();
   }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -11,7 +11,6 @@ var renderComponents = function() {
 }
 
 var tokenListener = function(changes) {
-  console.log("inside tokenlistener (main.js line 14)", changes);
   if (changes.access_token.newValue) {
     renderComponents();
     test.annotate();
@@ -20,20 +19,15 @@ var tokenListener = function(changes) {
 }
 
 chrome.storage.sync.get('access_token', function(obj) {
-  console.log('main.js > chrome storage get token (line 23)');
   if (obj['access_token']) {
-    console.log('main.js > chrome storage get token > if ( access token ) (line 25)');
     renderComponents();
-    console.log('main.js > chrome.storage.sync.get > if ( access token ) (line 27)');
     test.annotate();
   } else {
-    console.log('main.js > chrome.storage.sync.get > else (line 30)');
     chrome.storage.onChanged.addListener(tokenListener);
   }
 })
 
 var identityListener = function(changes) {
-  console.log("inside identitylistener (main.js line 36)", changes);
   if (changes.facebook_id.newValue) {
     renderComponents();
     test.annotate();
@@ -42,14 +36,10 @@ var identityListener = function(changes) {
 }
 
 chrome.storage.sync.get('facebook_id', function(obj) {
-  console.log('main.js > chrome.storage get fb id (line 45)');
   if (obj['access_token']) {
-    console.log('main.js > chrome storage get fb id > if ( access token ) (line 47)');
     renderComponents();
-    console.log('main.js > chrome storage get fb id > if ( access token ) (line 49)');
     test.annotate();
   } else {
-    console.log('main.js > chrome storage get fb id > else (line 52)');
     chrome.storage.onChanged.addListener(identityListener);
   }
 })

--- a/src/js/test.js
+++ b/src/js/test.js
@@ -26,21 +26,28 @@ exports.annotate = function(event) {
      .include(pageUri)
      .include(renderAnnotations);
 
-  app.start()
-     .then(function() {
-        chrome.storage.sync.get('facebook_id', function(obj) {
-          console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 32), obj:', obj);
-          if (!obj['facebook_id']) {
-            console.error('Unable to access facebook_id from chrome.storage (test.js line 34)');
-            return;
-          }
-          console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 37), obj.facebook_id:', obj.facebook_id);
-          app.ident.identity = obj.facebook_id;
-          console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 39), app.ident.identity:', app.ident.identity);
-          console.log('line app.ident.identity = obj.facebook_id; success?');
-          app.annotations.load({uri: window.location.href.split("?")[0]});
-        });
-     })
+  chrome.storage.sync.get('facebook_id', function(obj) {
+    console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 32), obj:', obj);
+    if (!obj['facebook_id']) {
+      console.error('Unable to access facebook_id from chrome.storage (test.js line 34)');
+      return;
+    }
+    console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 37), obj.facebook_id:', obj.facebook_id);
+
+    app.start()
+       .then(function() {
+        debugger;
+         app.ident.identity = obj.facebook_id;
+         console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 39), app.ident.identity:', app.ident.identity);
+         console.log('line app.ident.identity = obj.facebook_id; success?');
+         console.log('test.js > app.start().then() cb > chro.stor.sync.get(fbID) (line 42), app.ident:', app.ident);
+         var a = app;
+         var ai = app.ident;
+         var aii = app.ident.identity;
+         app.annotations.load({uri: window.location.href.split("?")[0]});
+       })
+  });
+
 
 
 

--- a/src/js/test.js
+++ b/src/js/test.js
@@ -33,6 +33,7 @@ exports.annotate = function(event) {
     app.start()
        .then(function() {
          window.localStorage.setItem('facebook_id', obj.facebook_id);
+         console.log('facebook_id set in localStorage');
          app.annotations.load({uri: window.location.href.split("?")[0]});
        });
   });

--- a/src/js/test.js
+++ b/src/js/test.js
@@ -13,6 +13,7 @@ exports.annotate = function(event) {
 
   var app = new annotator.App();
   app.include(annotator.ui.main)
+     .include(annotator.identity.simple)
      .include(annotator.storage.http, {
         prefix: 'https://onwords-test-server.herokuapp.com',
         urls: {
@@ -27,7 +28,18 @@ exports.annotate = function(event) {
 
   app.start()
      .then(function() {
-        app.annotations.load({uri: window.location.href.split("?")[0]});
+        chrome.storage.sync.get('facebook_id', function(obj) {
+          console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 32), obj:', obj);
+          if (!obj['facebook_id']) {
+            console.error('Unable to access facebook_id from chrome.storage (test.js line 34)');
+            return;
+          }
+          console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 37), obj.facebook_id:', obj.facebook_id);
+          app.ident.identity = obj.facebook_id;
+          console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 39), app.ident.identity:', app.ident.identity);
+          console.log('line app.ident.identity = obj.facebook_id; success?');
+          app.annotations.load({uri: window.location.href.split("?")[0]});
+        });
      })
 
 

--- a/src/js/test.js
+++ b/src/js/test.js
@@ -13,7 +13,6 @@ exports.annotate = function(event) {
 
   var app = new annotator.App();
   app.include(annotator.ui.main)
-     .include(annotator.identity.simple)
      .include(annotator.storage.http, {
         prefix: 'https://onwords-test-server.herokuapp.com',
         urls: {
@@ -27,28 +26,14 @@ exports.annotate = function(event) {
      .include(renderAnnotations);
 
   chrome.storage.sync.get('facebook_id', function(obj) {
-    console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 32), obj:', obj);
     if (!obj['facebook_id']) {
-      console.error('Unable to access facebook_id from chrome.storage (test.js line 34)');
+      console.error('Unable to access facebook_id from chrome.storage');
       return;
     }
-    console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 37), obj.facebook_id:', obj.facebook_id);
-
     app.start()
        .then(function() {
-        debugger;
-         app.ident.identity = obj.facebook_id;
-         console.log('test.js > callback of app.start().then() > chrome.storage.sync.get(\'facebook_id\') (line 39), app.ident.identity:', app.ident.identity);
-         console.log('line app.ident.identity = obj.facebook_id; success?');
-         console.log('test.js > app.start().then() cb > chro.stor.sync.get(fbID) (line 42), app.ident:', app.ident);
-         var a = app;
-         var ai = app.ident;
-         var aii = app.ident.identity;
+         window.localStorage.setItem('facebook_id', obj.facebook_id);
          app.annotations.load({uri: window.location.href.split("?")[0]});
-       })
+       });
   });
-
-
-
-
 }


### PR DESCRIPTION
**annotator-original.js**: added search query concatenation to URL call (but it’s currently commented out! gotta uncomment to allow it), commented out debugger statements
**auth.js**: added back setting `facebook_id` in `chrome.storage.sync`
**annotator-body.js**: added short-circuiting to `if` statement in `chrome.storage.onChanged` listener
**main.js**: fixed `identityListener` and replaced `tokenListener` with it
**test.js**: added retrieval of `facebook_id` from `chrome.storage.sync`, moved `app.start()` code to callback of said retrieval, and added setting of `facebook_id` to `localStorage` in the callback passed to the `.then()` that follows `app.start()`
